### PR TITLE
Fix typo in the default response message

### DIFF
--- a/nginx-config/nginx.conf
+++ b/nginx-config/nginx.conf
@@ -113,7 +113,7 @@ http {
     client_max_body_size 1G;
 
     location / {
-        return 200 'This is a caching service for gitub:  https://github.com/Azure/github-nginx-cache/';
+        return 200 'This is a caching service for github:  https://github.com/Azure/github-nginx-cache/';
         add_header Content-Type text/plain;
     }
 


### PR DESCRIPTION
This pull request fixes a typo in the default response message.

(Additional suggestion)
It would be great if we can use the official name `GitHub` in the response messages, docs, and comments.

- `nginx-config/health_check.conf`
    - `"Github cache is alive"` -> `"GitHub cache is alive"`
- `nginx-config/common_cache_settings.conf`
    - `github` -> `GitHub`
- etc
